### PR TITLE
Add imageio[ffmpeg] to enviroment.yaml to save MP4 in gradio app

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
     - transformers==4.25.1
     - xformers==0.0.16
     - imageio==2.27.0
+    - imageio[ffmpeg]
     - gdown
     - einops
     - omegaconf


### PR DESCRIPTION
This PR adds imageio[ffmpeg] to environment.yaml. Without it, the gradio app fails to save MP4:
```
ValueError: Could not find a backend to open `/home/user/git/AnimateDiff/samples/Gradio-2023-08-11T10-49-38/sample/0.mp4`` with iomode `wI`.
Based on the extension, the following plugins might add capable backends:
  FFMPEG:  pip install imageio[ffmpeg]
  pyav:  pip install imageio[pyav]
```
