### PR TITLE
fix(security): don't create a public share by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -325,4 +325,4 @@ def ui():
 
 if __name__ == "__main__":
     demo = ui()
-    demo.launch(share=True)
+    demo.launch(share=False)


### PR DESCRIPTION
Gradio's public sharing setting was hard coded to be on which is a big security risk.

This PR disable creating a public shared link by default.