### PR TITLE
[fix]: add torchaudio version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch==2.3.1
 torchvision==0.18.1
+torchaudio==2.3.1
 diffusers==0.11.1
 transformers==4.25.1
 xformers==0.0.27


### PR DESCRIPTION
# What does this PR do?
This PR adds the torchaudio version to the requirements.txt file. According to the official PyTorch website (https://pytorch.org/get-started/previous-versions/), it is recommended to install torch version 2.3.1, torchvision version 0.18.1, and torchaudio version 2.3.1.
![pytorch_requirement](https://github.com/user-attachments/assets/bb280dc0-5bc9-4883-a95a-687e0137f880)
